### PR TITLE
Make multiworld kubernetes friendly again

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -296,33 +296,24 @@ async def process_client_cmd(ctx : Context, client : Client, cmd, args):
         if args[0] == '!forfeit':
             forfeit_player(ctx, client.team, client.slot, client.name)
 
-        if args[0] == '!forfeitslot' and len(args) == 3 and args[2].isdigit():
-            if client.admin:
+        if client.admin:
+            if args[0] == '!forfeitslot' and len(args) == 3 and args[2].isdigit():
                 team = client.team
                 slot = int(args[1])
                 name = get_player_name_in_team(ctx, team, slot)
                 forfeit_player(ctx, team, slot, name)
-            else:
-                notify_client(client, '[Server]: Insufficient access')
 
-        if args[0] == '!forfeitplayer' and len(args) > 1:
-            if client.admin:
+            if args[0] == '!forfeitplayer' and len(args) > 1:
                 client = get_client_from_name(ctx, args[1])
                 if client:
                     forfeit_player(ctx, client.team, client.slot, client.name)
-            else:
-                notify_client(client, '[Server]: Insufficient access')
 
-        if args[0] == '!kick' and len(args) > 1:
-            if client.admin:
+            if args[0] == '!kick' and len(args) > 1:
                 client = get_client_from_name(ctx, args[1])
                 if client and client.socket and not client.socket.closed:
                     await client.socket.close()
-            else:
-                notify_client(client, '[Server]: Insufficient access')
 
-        if args[0] == '!senditem' and len(args) > 2:
-            if client.admin:
+            if args[0] == '!senditem' and len(args) > 2:
                 [(player, item)] = re.findall(r'\S* (\S*) (.*)', args)
                 if item in Items.item_table:
                     client = get_client_from_name(ctx, player)
@@ -331,14 +322,11 @@ async def process_client_cmd(ctx : Context, client : Client, cmd, args):
                         get_received_items(ctx, client.team, client.slot).append(new_item)
                         notify_all(ctx, 'Cheat console: sending "' + item + '" to ' + client.name)
                     send_new_items(ctx)
-            else:
-                notify_client(client, '[Server]: Insufficient access')
 
-        if args[0] == '!password':
-            if client.slot == admin.slot:
-                set_password(ctx, args[1])
-            else:
-                notify_all(ctx, '[Server]: Insufficient access')
+            if args[0] == '!password':
+                set_password(ctx, args[1] if len(args) > 1 else None)
+        else:
+            notify_client(client, '[Server]: Insufficient access')
 
 def set_password(ctx : Context, password):
     ctx.password = password

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -324,7 +324,9 @@ async def process_client_cmd(ctx : Context, client : Client, cmd, args):
                     send_new_items(ctx)
 
             if args[0] == '!password':
-                set_password(ctx, args[1] if len(args) > 1 else None)
+                password = args[1] if len(args) > 1 else None
+                set_password(ctx, password)
+                notify_client(client, '[Server]: Password has been set to ' + password)
         else:
             notify_client(client, '[Server]: Insufficient access')
 

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -326,7 +326,7 @@ async def process_client_cmd(ctx : Context, client : Client, cmd, args):
             if args[0] == '!password':
                 password = args[1] if len(args) > 1 else None
                 set_password(ctx, password)
-                notify_client(client, '[Server]: Password has been set to ' + password)
+                notify_client(client, '[Server]: Password has been set to ' + str(password))
         else:
             notify_client(client, '[Server]: Insufficient access')
 


### PR DESCRIPTION
We have a project that runs the multiserver.py in a docker containter within kubernetes and since kubernetes doesn't play well with things that are listening on stdin we would like to be able to disable console.

However, we don't want to lose the features that console has and so propose that it one can enable them over chat with an admin password set upon starting up multiserver.

I followed the previous command sets that were handled by say and prefixed them with ! instead of /, it might be a good idea to use / to distinguish them as admin commands.

I'm also not extremely satisfied with the code duplication of commands, but except for the case with senditem most are already fairly abstracted.