### PR TITLE
Serialize multidata in JSON instead of pickle

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -142,7 +142,7 @@ def main(args, seed=None):
 
     jsonout = {}
     if not args.suppress_rom:
-        from MultiServer import MultiWorld
+        from MultiWorld import MultiWorld
         multidata = MultiWorld()
         multidata.players = world.players
 
@@ -169,7 +169,7 @@ def main(args, seed=None):
             multidata.rom_names[player] = list(rom.name)
             for location in world.get_filled_locations(player):
                 if type(location.address) is int:
-                    multidata.locations[(location.address, player)] = (location.item.code, location.item.player)
+                    multidata.locations.setdefault(player, dict())[location.address] = [location.item.code, location.item.player]
 
             if args.jsonout:
                 jsonout[f'patch{player}'] = rom.patches
@@ -208,8 +208,7 @@ def main(args, seed=None):
                                                                           "-nohints" if not world.hints[player] else "")) if not args.outputname else ''
                 rom.write_to_file(output_path(f'{outfilebase}{playername}{outfilesuffix}.sfc'))
 
-        with open(output_path('%s_multidata' % outfilebase), 'wb') as f:
-            pickle.dump(multidata, f, pickle.HIGHEST_PROTOCOL)
+        multidata.write(output_path('%s_multidata' % outfilebase))
 
     if args.create_spoiler and not args.jsonout:
         world.spoiler.to_file(output_path('%s_Spoiler.txt' % outfilebase))

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -11,6 +11,7 @@ import websockets
 
 import Items
 import Regions
+from MultiWorld import MultiWorld
 from MultiClient import ReceivedItem, get_item_name_from_id, get_location_name_from_address
 
 class Client:
@@ -21,12 +22,6 @@ class Client:
         self.team = None
         self.slot = None
         self.send_index = 0
-
-class MultiWorld:
-    def __init__(self):
-        self.players = None
-        self.rom_names = {}
-        self.locations = {}
 
 class Context:
     def __init__(self, host, port, password):
@@ -175,8 +170,8 @@ def forfeit_player(ctx : Context, team, slot, name):
 def register_location_checks(ctx : Context, name, team, slot, locations):
     found_items = False
     for location in locations:
-        if (location, slot) in ctx.world.locations:
-            target_item, target_player = ctx.world.locations[(location, slot)]
+        if slot in ctx.world.locations and location in ctx.world.locations[slot]:
+            target_item, target_player = ctx.world.locations[slot][location]
             if target_player != slot:
                 found = False
                 recvd_items = get_received_items(ctx, team, target_player)
@@ -357,8 +352,7 @@ async def main():
             root.withdraw()
             ctx.data_filename = tkinter.filedialog.askopenfilename(filetypes=(("Multiworld data","*multidata"),))
 
-        with open(ctx.data_filename, 'rb') as f:
-            ctx.world = pickle.load(f)
+        ctx.world = MultiWorld.load(ctx.data_filename)
     except Exception as e:
         print('Failed to read multiworld data (%s)' % e)
         return

--- a/MultiWorld.py
+++ b/MultiWorld.py
@@ -1,0 +1,44 @@
+import json
+
+def pythonify(json_data):
+    str_keys = []
+    for key, value in json_data.items():
+        if isinstance(value, list):
+            value = [pythonify(item) if isinstance(item, dict) else item for item in value]
+        elif isinstance(value, dict):
+            value = pythonify(value)
+
+        if isinstance(key, str):
+            str_keys.append(key)
+
+    for key in str_keys:
+        try:
+            newkey = int(key)
+            json_data[newkey] = json_data[key]
+            del json_data[key]
+        except ValueError:
+            pass
+
+    return json_data
+
+class MultiWorld:
+    def __init__(self):
+        self.players = None
+        self.rom_names = {}
+        self.locations = {}
+
+    @classmethod
+    def load(cls, name):
+        with open(name, 'r') as f:
+            json_data = pythonify(json.load(f))
+
+            multiworld = MultiWorld()
+            multiworld.players = json_data['players']
+            multiworld.rom_names = json_data['rom_names']
+            multiworld.locations = json_data['locations']
+
+            return multiworld
+    
+    def write(self, name):
+        with open(name, 'w') as f:
+            json.dump(self.__dict__, f)


### PR DESCRIPTION
The pickle library is a security risk if used with user input, so migrate the format to JSON instead.
The format changes a bit as tuples can't be exported to JSON, I made the locations dictionary indexed by player name and then location and the (code, player) information a list instead.
JSON does not support integer key either, so they are exported as strings and converted back when reading.

It will also help alternate server implementations to import the data file without having to process a pure Python format.